### PR TITLE
Populated homepage with existing artists and products

### DIFF
--- a/group06-handcrafted-haven/pnpm-workspace.yaml
+++ b/group06-handcrafted-haven/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 onlyBuiltDependencies:
+  - '@prisma/client'
   - '@prisma/engines'
   - esbuild
   - prisma

--- a/group06-handcrafted-haven/src/app/lib/data.ts
+++ b/group06-handcrafted-haven/src/app/lib/data.ts
@@ -1,15 +1,25 @@
-import { NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
+// import { NextResponse } from "next/server";
+import { PrismaClient, Product, User } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
-export async function getTenProducts() {
+//defines a type for the props of the components
+export type ProductWithArtist = Product & {
+  artist: User;
+};
+
+//avoid exposing sensitive information about the artist
+export type PublicArtist = {
+  artist: Pick<User, "id" | "name" | "email" | "isArtist" | "createdAt">;
+};
+
+export async function getTenProducts(): Promise<ProductWithArtist[]> {
   const products = await prisma.product.findMany({
     take: 10,
     orderBy: { createdAt: "desc" }, // newest first
     include: { artist: true }, // include artist info if needed
   });
-  return NextResponse.json(products);
+  return products;
 }
 
 // Fetch all artists
@@ -17,5 +27,13 @@ export async function getAllArtists() {
   return prisma.user.findMany({
     where: { isArtist: true },
     orderBy: { name: "asc" },
+  });
+}
+
+// Fetch singular artist
+export async function getArtistById(id: string) {
+  return await prisma.user.findUnique({
+    where: { id },
+    include: { products: true },
   });
 }

--- a/group06-handcrafted-haven/src/app/ui/artist/products-by-artist.tsx
+++ b/group06-handcrafted-haven/src/app/ui/artist/products-by-artist.tsx
@@ -1,14 +1,10 @@
-import { ProductCard } from "@/app/ui/cards";
+// import { ProductCard } from "@/app/ui/cards";
 
 export default async function ProductsByArtist() {
   return (
     <div>
       <h2>Artist&apos;s Products</h2>
       {/* Display all of the artists products */}
-      <ProductCard />
-      <ProductCard />
-      <ProductCard />
-      <ProductCard />
     </div>
   );
 }

--- a/group06-handcrafted-haven/src/app/ui/cards.tsx
+++ b/group06-handcrafted-haven/src/app/ui/cards.tsx
@@ -1,29 +1,41 @@
 import Link from "next/link";
+// import Image from "next/image";
+import { ProductWithArtist, PublicArtist } from "@/app/lib/data";
 
-export function ProductCard() {
-  //uses props to populate i.e title, image, description
+type ProductCardProps = {
+  product: ProductWithArtist;
+};
+
+export function ProductCard({ product }: ProductCardProps) {
   return (
     <li>
       {/* link to product page */}
       <Link href="#">
         <div>
-          {/* Picture from product */}
-          <h3>Product title</h3>
-          <p>Product description</p>
-          {/* should artist name also appear? */}
+          {/* cannot display image since they are placeholders from external sources */}
+          {/* {product.imageUrl && (
+            <Image
+              src={product.imageUrl}
+              alt={product.title}
+              width={300}
+              height={300}
+            />
+          )} */}
+          <h3>{product.title}</h3>
+          <p>{product.description}</p>
         </div>
       </Link>
     </li>
   );
 }
 
-export function ArtistCard() {
+export function ArtistCard({ artist }: PublicArtist) {
   return (
     <li>
-      {/* link to the artists profile */}
-      <Link href="#">
+      <Link href={`/artist/${artist.id}`}>
         {/* artist profile picture */}
-        <h3>Username</h3>
+        <h3>{artist.name}</h3>
+        <p>{artist.email}</p>
       </Link>
     </li>
   );

--- a/group06-handcrafted-haven/src/app/ui/homepage/top-artists.tsx
+++ b/group06-handcrafted-haven/src/app/ui/homepage/top-artists.tsx
@@ -1,16 +1,17 @@
 import { frederickaTheGreat } from "@/app/ui/fonts";
 import { ArtistCard } from "@/app/ui/cards";
+import { getAllArtists } from "@/app/lib/data";
 
 export default async function TopArtists() {
-  // functionality for showing artists
+  const artists = await getAllArtists();
+
   return (
     <section>
       <h2 className={`${frederickaTheGreat.className}`}>Top Artists</h2>
       <ul>
-        {/* .map artist card */}
-        <ArtistCard />
-        <ArtistCard />
-        <ArtistCard />
+        {artists.map((artist) => (
+          <ArtistCard key={artist.id} artist={artist} />
+        ))}
       </ul>
     </section>
   );

--- a/group06-handcrafted-haven/src/app/ui/homepage/top-products.tsx
+++ b/group06-handcrafted-haven/src/app/ui/homepage/top-products.tsx
@@ -1,16 +1,17 @@
 import { frederickaTheGreat } from "@/app/ui/fonts";
 import { ProductCard } from "@/app/ui/cards";
+import { getTenProducts } from "@/app/lib/data";
 
 export default async function TopProducts() {
-  // functionality for showing products, uses fetch to obtain data and passes it down to the cards
+  const top10 = await getTenProducts();
+
   return (
     <section>
       <h2 className={`${frederickaTheGreat.className}`}>Top Products</h2>
       <ul>
-        {/* .map product card */}
-        <ProductCard />
-        <ProductCard />
-        <ProductCard />
+        {top10.map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
       </ul>
     </section>
   );


### PR DESCRIPTION
#3 

# Done
* Used data from the database to populate the home page highlights with the existing products and artists
* Added a getArtistById to data.ts to later fecth artists information for artists pages
* Added some types to data.ts to be able to use props in components
* Links to artist page now work (pages still need to be populated with the information)

## Notes
* Decided to not continue with the functionality of the artists pages since that is a separate issue that should be worked on a different branch. 
* Products-by-artist doesn't call ProductCard (temporarily) since now ProductCard takes a prop and passing the prop from the artist page requires extra code not yet worked on
* Images cant be rendered since they are from external links and Next blocks that
* We should add a description for users to add to their profile to the prisma schemas